### PR TITLE
Part 2 feat: Update math functions edge cases and unit tests for FormulaEvaluator

### DIFF
--- a/src/Engine/FormulaEvaluator.ts
+++ b/src/Engine/FormulaEvaluator.ts
@@ -205,7 +205,7 @@ export class FormulaEvaluator {
           break;
         case "tan":
           this._currentFormula.shift();
-          if (result === 90 || result === 270) {
+          if (Math.abs(result) === 90 || Math.abs(result) === 270) {
             this._errorOccured = true;
             this._errorMessage = ErrorMessages.invalidNumber;
             this._lastResult = NaN;
@@ -216,10 +216,22 @@ export class FormulaEvaluator {
           break;
         case "sin^-1":
           this._currentFormula.shift();
+          if (result < -1 || result > 1) {
+            this._errorOccured = true;
+            this._errorMessage = ErrorMessages.outOfRange;
+            this._lastResult = NaN;
+            return this._lastResult;
+          }
           result = Math.asin(result);
           break;
         case "cos^-1":
           this._currentFormula.shift();
+          if (result < -1 || result > 1) {
+            this._errorOccured = true;
+            this._errorMessage = ErrorMessages.outOfRange;
+            this._lastResult = NaN;
+            return this._lastResult;
+          }
           result = Math.acos(result);
           break;
         case "tan^-1":

--- a/src/Engine/GlobalDefinitions.ts
+++ b/src/Engine/GlobalDefinitions.ts
@@ -9,6 +9,7 @@ export const ErrorMessages = {
   missingParentheses: "#ERR",
   emptyFormula: "#EMPTY!", // this is not an error message but we use it to indicate that the cell is empty
   negativeRoot: "#ERR",
+  outOfRange: "#ERR",
 
 }
 

--- a/src/Tests/Unit/FormulaEvaluator.test.ts
+++ b/src/Tests/Unit/FormulaEvaluator.test.ts
@@ -685,6 +685,45 @@ describe("FormulaEvaluator", () => {
         let error = recalc.error;
 
         expect(result).toEqual(NaN);
+        expect(error).toEqual(ErrorMessages.outOfRange);
+      });
+    });     
+
+    describe("when the formula is cos^(-1)(2)", () => {
+      it("returns the number", () => {
+        const formula = ["2", "cos^-1"];
+        recalc.evaluate(formula);
+
+        let result = recalc.result;
+        let error = recalc.error;
+
+        expect(result).toEqual(NaN);
+        expect(error).toEqual(ErrorMessages.outOfRange);
+      });
+    });     
+
+    describe("when the formula is cos^(-1)(0) * 10", () => {
+      it("returns the number", () => {
+        const formula = ["0", "cos^-1", "*", "10"];
+        recalc.evaluate(formula);
+
+        let result = recalc.result;
+        let error = recalc.error;
+
+        expect(result).toEqual(Math.acos(0) * 10);
+        expect(error).toEqual("");
+      });
+    });     
+
+    describe("when the formula is (tan^(-1)(1) - 5) / 2", () => {
+      it("returns the number", () => {
+        const formula = ["(", "1", "tan^-1", "-", "5", ")", "/", "2"];
+        recalc.evaluate(formula);
+
+        let result = recalc.result;
+        let error = recalc.error;
+
+        expect(result).toEqual((Math.atan(1) - 5) / 2);
         expect(error).toEqual("");
       });
     });     
@@ -711,6 +750,19 @@ describe("FormulaEvaluator", () => {
         let error = recalc.error;
 
         expect(result).toEqual(0);
+        expect(error).toEqual("");
+      });
+    });     
+
+    describe("when the formula is +/- -3 + 3", () => {
+      it("returns the number", () => {
+        const formula = ["-3", "+/-", "+", "3"];
+        recalc.evaluate(formula);
+
+        let result = recalc.result;
+        let error = recalc.error;
+
+        expect(result).toEqual(6);
         expect(error).toEqual("");
       });
     });     


### PR DESCRIPTION
Handle edge cases for the below functions in FormulaEvaluator.ts
tan is undefined at some points (π/2, 3π/2).
sin^-1 (arcsin): its domain of definition is [-1, 1]. NaN is returned when values outside this range are given.
cos^-1 (arcsin): also defined as [-1, 1]. A value outside this range will return NaN.

Update corresponding test cases in FormulaEvaluator.test.ts.